### PR TITLE
Cached image timestamps

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,7 +79,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.6"
+    version: "1.2.9"
   ffi:
     dependency: transitive
     description:

--- a/lib/src/fast_cached_image.dart
+++ b/lib/src/fast_cached_image.dart
@@ -523,7 +523,7 @@ class FastCachedImageConfig {
     return false;
   }
 
-  ///[cachedDate] returns the date when the image was cached. If the image is not cached, it returns null.
+  ///[getCachedDate] returns the date when the image was cached. If the image is not cached, it returns null.
   static Future<DateTime?> getCachedDate({required String imageUrl}) async {
     _checkInit();
 

--- a/lib/src/fast_cached_image.dart
+++ b/lib/src/fast_cached_image.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:ui' as ui;
+
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:uuid/uuid.dart';
+
 import 'models/fast_cache_progress_data.dart';
-import 'package:dio/dio.dart';
 
 class FastCachedImage extends StatefulWidget {
   ///Provide the [url] for the image to display.
@@ -519,6 +521,17 @@ class FastCachedImageConfig {
       return true;
     }
     return false;
+  }
+
+  ///[cachedDate] returns the date when the image was cached. If the image is not cached, it returns null.
+  static Future<DateTime?> getCachedDate({required String imageUrl}) async {
+    _checkInit();
+
+    final key = _keyFromUrl(imageUrl);
+    if (_imageKeyBox!.containsKey(key)) {
+      return await _imageKeyBox!.get(key);
+    }
+    return null;
   }
 
   static _keyFromUrl(String url) => const Uuid().v5(Uuid.NAMESPACE_URL, url);


### PR DESCRIPTION
Adding the ability to access the timestamp when an image was cached would enable the ability to implement custom cache invalidation techniques. For this, I request to add a method to get the timestamp when an image was cached, if it was cached.

My proposal is to simply add a static method: `static Future<DateTime?> getCachedDate({required String imageUrl})`, which returns the cached date, or null if no cached image is available. Looking at the package's source code, this should be fairly simple as the package already stores timestamps for cached files.

An example of a use case of this would be in an app where a widget displays an image from a Firebase Storage file, where the file could be updated externally at any time. Firebase storage does not currently have a way to notify the client when a file is updated, so a way to solve this would be to store an updatedAt timestamp in the file's metadata, so we just need to fetch the metadata of the file to access its timestamp. With the getCachedDate method, we can then compare our cached image's timestamp with the updatedAt timestamp of the file in the cloud, and invalidate our local cached image if it is outdated.